### PR TITLE
fixed token_int  is zero bug and add more puncs to sentence

### DIFF
--- a/funasr/bin/asr_inference_paraformer_vad_punc.py
+++ b/funasr/bin/asr_inference_paraformer_vad_punc.py
@@ -292,6 +292,8 @@ class Speech2Text:
 
                 # remove blank symbol id, which is assumed to be 0
                 token_int = list(filter(lambda x: x != 0 and x != 2, token_int))
+                if len(token_int) == 0:
+                    continue
 
                 # Change integer-ids to tokens
                 token = self.converter.ids2tokens(token_int)


### PR DESCRIPTION
## If token_int is 0, the following process will crash. This BUG has been fixed. In fact, when token_int=0, there is no need to continue processing. 
## modify time_stamp_sentence to support more punc.