### PR TITLE
Fix timestamp prediction on empty ASR outputs

### DIFF
--- a/funasr/utils/timestamp_tools.py
+++ b/funasr/utils/timestamp_tools.py
@@ -17,7 +17,7 @@ def ts_prediction_lfr6_standard(us_alphas,
                        sil_in_str=True
                        ):
     if not len(char_list):
-        return []
+        return "", []
     START_END_THRESHOLD = 5
     MAX_TOKEN_DURATION = 12
     TIME_RATE = 10.0 * 6 / 1000 / 3  #  3 times upsampled


### PR DESCRIPTION
When I run Paraformer-large-vad-punc inference on certain audio files, I get:

>   File "/public/zhangyuanhang/installs/FunASR/funasr/bin/asr_inference_paraformer_vad_punc.py", line 305, in __c
all__                                                                                 
    _, timestamp = ts_prediction_lfr6_standard(us_alphas[i],                                                    
ValueError: not enough values to unpack (expected 2, got 0)

If `char_list` is empty, we should still return both the text (which is empty string) and the timestamps to fit the function signature.