### PR TITLE
使用np.float32替换np.float

### DIFF
--- a/funasr/models/frontend/wav_frontend.py
+++ b/funasr/models/frontend/wav_frontend.py
@@ -30,8 +30,8 @@ def load_cmvn(cmvn_file):
                 rescale_line = line_item[3:(len(line_item) - 1)]
                 vars_list = list(rescale_line)
                 continue
-    means = np.array(means_list).astype(np.float)
-    vars = np.array(vars_list).astype(np.float)
+    means = np.array(means_list).astype(np.float32)
+    vars = np.array(vars_list).astype(np.float32)
     cmvn = np.array([means, vars])
     cmvn = torch.as_tensor(cmvn, dtype=torch.float32)
     return cmvn


### PR DESCRIPTION
新的numpy, 已经不支持np.float

> `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
> The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
>     https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

使用测试代码
```
from modelscope.pipelines import pipeline
from modelscope.utils.constant import Tasks

inference_pipeline = pipeline(
    task=Tasks.auto_speech_recognition,
    model='damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch',
)

rec_result = inference_pipeline(audio_in='1475347516.wav')
print(rec_result)
```
错误信息
```
2023-07-30 23:32:25,513 - modelscope - WARNING - No preprocessor key ('generic-asr', 'auto-speech-recognition') found in PREPROCESSOR_MAP, skip building preprocessor.
Traceback (most recent call last):
  File "/opt/conda/envs/funasr/lib/python3.10/site-packages/modelscope/utils/registry.py", line 212, in build_from_cfg
    return obj_cls(**args)
  File "/opt/conda/envs/funasr/lib/python3.10/site-packages/modelscope/pipelines/audio/asr_inference_pipeline.py", line 124, in __init__
    self.funasr_infer_modelscope = asr_inference_launch.inference_launch(
  File "/data/jovyan/work/FunASR/funasr/bin/asr_inference_launch.py", line 1624, in inference_launch
    return inference_paraformer(**kwargs)
  File "/data/jovyan/work/FunASR/funasr/bin/asr_inference_launch.py", line 295, in inference_paraformer
    speech2text = Speech2TextParaformer(**speech2text_kwargs)
  File "/data/jovyan/work/FunASR/funasr/bin/asr_infer.py", line 290, in __init__
    asr_model, asr_train_args = build_model_from_file(
  File "/data/jovyan/work/FunASR/funasr/build_utils/build_model_from_file.py", line 47, in build_model_from_file
    model = build_model(args)
  File "/data/jovyan/work/FunASR/funasr/build_utils/build_model.py", line 12, in build_model
    model = build_asr_model(args)
  File "/data/jovyan/work/FunASR/funasr/build_utils/build_asr_model.py", line 290, in build_asr_model
    frontend = frontend_class(cmvn_file=args.cmvn_file, **args.frontend_conf)
  File "/data/jovyan/work/FunASR/funasr/models/frontend/wav_frontend.py", line 111, in __init__
    self.cmvn = None if self.cmvn_file is None else load_cmvn(self.cmvn_file)
  File "/data/jovyan/work/FunASR/funasr/models/frontend/wav_frontend.py", line 33, in load_cmvn
    means = np.array(means_list).astype(np.float)
  File "/opt/conda/envs/funasr/lib/python3.10/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'cfloat'?

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/jovyan/work/FunASR/m0.py", line 4, in <module>
    inference_pipeline = pipeline(
  File "/opt/conda/envs/funasr/lib/python3.10/site-packages/modelscope/pipelines/builder.py", line 147, in pipeline
    return build_pipeline(cfg, task_name=task)
  File "/opt/conda/envs/funasr/lib/python3.10/site-packages/modelscope/pipelines/builder.py", line 59, in build_pipeline
    return build_from_cfg(
  File "/opt/conda/envs/funasr/lib/python3.10/site-packages/modelscope/utils/registry.py", line 215, in build_from_cfg
    raise type(e)(f'{obj_cls.__name__}: {e}')
AttributeError: AutomaticSpeechRecognitionPipeline: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

为此将np.float都修改为np.float32