### PR TITLE
解决Microsoft Visual C++ 2022 编译错误

### DIFF
--- a/funasr/runtime/onnxruntime/include/funasrruntime.h
+++ b/funasr/runtime/onnxruntime/include/funasrruntime.h
@@ -105,9 +105,6 @@ _FUNASRAPI FUNASR_RESULT	FunOfflineInferBuffer(FUNASR_HANDLE handle, const char*
 _FUNASRAPI FUNASR_RESULT	FunOfflineInfer(FUNASR_HANDLE handle, const char* sz_filename, FUNASR_MODE mode, 
 											QM_CALLBACK fn_callback, const std::vector<std::vector<float>> &hw_emb, 
 											int sampling_rate=16000, bool itn=true);
-#if !defined(__APPLE__)
-_FUNASRAPI const std::vector<std::vector<float>> CompileHotwordEmbedding(FUNASR_HANDLE handle, std::string &hotwords, ASR_TYPE mode=ASR_OFFLINE);
-#endif
 
 _FUNASRAPI void				FunOfflineUninit(FUNASR_HANDLE handle);
 
@@ -125,4 +122,8 @@ _FUNASRAPI void				FunTpassOnlineUninit(FUNASR_HANDLE handle);
 #ifdef __cplusplus 
 
 }
+#endif
+
+#if !defined(__APPLE__)
+_FUNASRAPI const std::vector<std::vector<float>> CompileHotwordEmbedding(FUNASR_HANDLE handle, std::string& hotwords, ASR_TYPE mode = ASR_OFFLINE);
 #endif

--- a/funasr/runtime/onnxruntime/src/audio.cpp
+++ b/funasr/runtime/onnxruntime/src/audio.cpp
@@ -9,6 +9,9 @@
 #include "audio.h"
 #include "precomp.h"
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996)
+#endif
 
 #if defined(__APPLE__)
 #include <string.h>

--- a/funasr/runtime/onnxruntime/src/commonfunc.h
+++ b/funasr/runtime/onnxruntime/src/commonfunc.h
@@ -1,29 +1,34 @@
 #pragma once 
 #include <algorithm>
+#ifdef _WIN32
+#include <codecvt>
+#endif
 
 namespace funasr {
 typedef struct
 {
-    std::string msg="";
-    std::string stamp="";
-    std::string tpass_msg="";
-    float snippet_time=0;
+    std::string msg;
+    std::string stamp;
+    std::string tpass_msg;
+    float snippet_time;
 }FUNASR_RECOG_RESULT;
 
 typedef struct
 {
     std::vector<std::vector<int>>* segments;
-    float  snippet_time=0;
+    float  snippet_time;
 }FUNASR_VAD_RESULT;
 
 typedef struct
 {
-    string msg="";
+    string msg;
     vector<string> arr_cache;
 }FUNASR_PUNC_RESULT;
 
 #ifdef _WIN32
-#include <codecvt>
+
+#define ORTSTRING(str) StrToWstr(str)
+#define ORTCHAR(str) StrToWstr(str).c_str()
 
 inline std::wstring String2wstring(const std::string& str, const std::string& locale)
 {
@@ -39,7 +44,14 @@ inline std::wstring  StrToWstr(std::string str) {
 
 }
 
+#else
+
+#define ORTSTRING(str) str
+#define ORTCHAR(str) str
+
 #endif
+
+
 
 inline void GetInputName(Ort::Session* session, string& inputName,int nIndex=0) {
     size_t numInputNodes = session->GetInputCount();

--- a/funasr/runtime/onnxruntime/src/ct-transformer-online.cpp
+++ b/funasr/runtime/onnxruntime/src/ct-transformer-online.cpp
@@ -17,7 +17,7 @@ void CTTransformerOnline::InitPunc(const std::string &punc_model, const std::str
     session_options.DisableCpuMemArena();
 
     try{
-        m_session = std::make_unique<Ort::Session>(env_, punc_model.c_str(), session_options);
+        m_session = std::make_unique<Ort::Session>(env_, ORTSTRING(punc_model).c_str(), session_options);
         LOG(INFO) << "Successfully load model from " << punc_model;
     }
     catch (std::exception const &e) {

--- a/funasr/runtime/onnxruntime/src/ct-transformer.cpp
+++ b/funasr/runtime/onnxruntime/src/ct-transformer.cpp
@@ -66,8 +66,8 @@ string CTTransformer::AddPunc(const char* sz_input)
     for (size_t i = 0; i < InputData.size(); i += TOKEN_LEN)
     {
         nDiff = (i + TOKEN_LEN) < InputData.size() ? (0) : (i + TOKEN_LEN - InputData.size());
-        vector<int32_t> InputIDs(InputData.begin() + i, InputData.begin() + i + TOKEN_LEN - nDiff);
-        vector<string> InputStr(strOut.begin() + i, strOut.begin() + i + TOKEN_LEN - nDiff);
+        vector<int32_t> InputIDs(InputData.begin() + i, InputData.begin() + i + (TOKEN_LEN - nDiff));
+        vector<string> InputStr(strOut.begin() + i, strOut.begin() + i + (TOKEN_LEN - nDiff));
         InputIDs.insert(InputIDs.begin(), RemainIDs.begin(), RemainIDs.end()); // RemainIDs+InputIDs;
         InputStr.insert(InputStr.begin(), RemainStr.begin(), RemainStr.end()); // RemainStr+InputStr;
 

--- a/funasr/runtime/onnxruntime/src/ct-transformer.cpp
+++ b/funasr/runtime/onnxruntime/src/ct-transformer.cpp
@@ -17,7 +17,7 @@ void CTTransformer::InitPunc(const std::string &punc_model, const std::string &p
     session_options.DisableCpuMemArena();
 
     try{
-        m_session = std::make_unique<Ort::Session>(env_, punc_model.c_str(), session_options);
+        m_session = std::make_unique<Ort::Session>(env_, ORTSTRING(punc_model).c_str(), session_options);
         LOG(INFO) << "Successfully load model from " << punc_model;
     }
     catch (std::exception const &e) {

--- a/funasr/runtime/onnxruntime/src/fsmn-vad.cpp
+++ b/funasr/runtime/onnxruntime/src/fsmn-vad.cpp
@@ -54,7 +54,7 @@ void FsmnVad::LoadConfigFromYaml(const char* filename){
 void FsmnVad::ReadModel(const char* vad_model) {
     try {
         vad_session_ = std::make_shared<Ort::Session>(
-                env_, vad_model, session_options_);
+                env_, ORTCHAR(vad_model), session_options_);
         LOG(INFO) << "Successfully load model from " << vad_model;
     } catch (std::exception const &e) {
         LOG(ERROR) << "Error when load vad onnx model: " << e.what();

--- a/funasr/runtime/onnxruntime/src/funasrruntime.cpp
+++ b/funasr/runtime/onnxruntime/src/funasrruntime.cpp
@@ -375,31 +375,6 @@ extern "C" {
 		return p_result;
 	}
 
-#if !defined(__APPLE__)
-	_FUNASRAPI const std::vector<std::vector<float>> CompileHotwordEmbedding(FUNASR_HANDLE handle, std::string &hotwords, ASR_TYPE mode)
-	{
-		if (mode == ASR_OFFLINE){
-			funasr::OfflineStream* offline_stream = (funasr::OfflineStream*)handle;
-    		std::vector<std::vector<float>> emb;
-			if (!offline_stream)
-				return emb;
-			return (offline_stream->asr_handle)->CompileHotwordEmbedding(hotwords);
-		}
-		else if (mode == ASR_TWO_PASS){
-			funasr::TpassStream* tpass_stream = (funasr::TpassStream*)handle;
-    		std::vector<std::vector<float>> emb;
-			if (!tpass_stream)
-				return emb;
-			return (tpass_stream->asr_handle)->CompileHotwordEmbedding(hotwords);
-		}
-		else{
-			LOG(ERROR) << "Not implement: Online model does not support Hotword yet!";
-			std::vector<std::vector<float>> emb;
-			return emb;
-		}
-		
-	}
-#endif
 
 	// APIs for 2pass-stream Infer
 	_FUNASRAPI FUNASR_RESULT FunTpassInferBuffer(FUNASR_HANDLE handle, FUNASR_HANDLE online_handle, const char* sz_buf, 
@@ -691,3 +666,28 @@ extern "C" {
 }
 #endif
 
+#if !defined(__APPLE__)
+_FUNASRAPI const std::vector<std::vector<float>> CompileHotwordEmbedding(FUNASR_HANDLE handle, std::string& hotwords, ASR_TYPE mode)
+{
+    if (mode == ASR_OFFLINE) {
+        funasr::OfflineStream* offline_stream = (funasr::OfflineStream*)handle;
+        std::vector<std::vector<float>> emb;
+        if (!offline_stream)
+            return emb;
+        return (offline_stream->asr_handle)->CompileHotwordEmbedding(hotwords);
+    }
+    else if (mode == ASR_TWO_PASS) {
+        funasr::TpassStream* tpass_stream = (funasr::TpassStream*)handle;
+        std::vector<std::vector<float>> emb;
+        if (!tpass_stream)
+            return emb;
+        return (tpass_stream->asr_handle)->CompileHotwordEmbedding(hotwords);
+    }
+    else {
+        LOG(ERROR) << "Not implement: Online model does not support Hotword yet!";
+        std::vector<std::vector<float>> emb;
+        return emb;
+    }
+
+}
+#endif

--- a/funasr/runtime/onnxruntime/src/offline-stream.cpp
+++ b/funasr/runtime/onnxruntime/src/offline-stream.cpp
@@ -1,5 +1,4 @@
 #include "precomp.h"
-#include <unistd.h>
 
 namespace funasr {
 OfflineStream::OfflineStream(std::map<std::string, std::string>& model_path, int thread_num)

--- a/funasr/runtime/onnxruntime/src/paraformer.cpp
+++ b/funasr/runtime/onnxruntime/src/paraformer.cpp
@@ -37,7 +37,7 @@ void Paraformer::InitAsr(const std::string &am_model, const std::string &am_cmvn
     session_options_.DisableCpuMemArena();
 
     try {
-        m_session_ = std::make_unique<Ort::Session>(env_, am_model.c_str(), session_options_);
+        m_session_ = std::make_unique<Ort::Session>(env_, ORTSTRING(am_model).c_str(), session_options_);
         LOG(INFO) << "Successfully load model from " << am_model;
     } catch (std::exception const &e) {
         LOG(ERROR) << "Error when load am onnx model: " << e.what();
@@ -90,7 +90,7 @@ void Paraformer::InitAsr(const std::string &en_model, const std::string &de_mode
     session_options_.DisableCpuMemArena();
 
     try {
-        encoder_session_ = std::make_unique<Ort::Session>(env_, en_model.c_str(), session_options_);
+        encoder_session_ = std::make_unique<Ort::Session>(env_, ORTSTRING(en_model).c_str(), session_options_);
         LOG(INFO) << "Successfully load model from " << en_model;
     } catch (std::exception const &e) {
         LOG(ERROR) << "Error when load am encoder model: " << e.what();
@@ -98,7 +98,7 @@ void Paraformer::InitAsr(const std::string &en_model, const std::string &de_mode
     }
 
     try {
-        decoder_session_ = std::make_unique<Ort::Session>(env_, de_model.c_str(), session_options_);
+        decoder_session_ = std::make_unique<Ort::Session>(env_, ORTSTRING(de_model).c_str(), session_options_);
         LOG(INFO) << "Successfully load model from " << de_model;
     } catch (std::exception const &e) {
         LOG(ERROR) << "Error when load am decoder model: " << e.what();
@@ -153,7 +153,7 @@ void Paraformer::InitAsr(const std::string &am_model, const std::string &en_mode
 
     // offline
     try {
-        m_session_ = std::make_unique<Ort::Session>(env_, am_model.c_str(), session_options_);
+        m_session_ = std::make_unique<Ort::Session>(env_, ORTSTRING(am_model).c_str(), session_options_);
         LOG(INFO) << "Successfully load model from " << am_model;
     } catch (std::exception const &e) {
         LOG(ERROR) << "Error when load am onnx model: " << e.what();
@@ -250,7 +250,7 @@ void Paraformer::InitHwCompiler(const std::string &hw_model, int thread_num) {
     hw_session_options.DisableCpuMemArena();
 
     try {
-        hw_m_session = std::make_unique<Ort::Session>(hw_env_, hw_model.c_str(), hw_session_options);
+        hw_m_session = std::make_unique<Ort::Session>(hw_env_, ORTSTRING(hw_model).c_str(), hw_session_options);
         LOG(INFO) << "Successfully load model from " << hw_model;
     } catch (std::exception const &e) {
         LOG(ERROR) << "Error when load hw compiler onnx model: " << e.what();

--- a/funasr/runtime/onnxruntime/src/precomp.h
+++ b/funasr/runtime/onnxruntime/src/precomp.h
@@ -17,6 +17,25 @@
 #include <numeric>
 #include <cstring>
 
+#ifdef _WIN32
+#include<io.h>
+#ifndef R_OK
+#define R_OK 4
+#endif
+#ifndef W_OK
+#define W_OK 2
+#endif
+#ifndef X_OK
+#define X_OK 0 
+#endif
+#ifndef F_OK
+#define F_OK 0
+#endif
+#define access _access
+#else
+#include <unistd.h>
+#endif
+
 using namespace std;
 // third part
 #if defined(__APPLE__)
@@ -33,6 +52,8 @@ using namespace std;
 
 // mine
 #include <glog/logging.h>
+
+
 #include "common-struct.h"
 #include "com-define.h"
 #include "commonfunc.h"

--- a/funasr/runtime/onnxruntime/src/tpass-online-stream.cpp
+++ b/funasr/runtime/onnxruntime/src/tpass-online-stream.cpp
@@ -1,5 +1,4 @@
 #include "precomp.h"
-#include <unistd.h>
 
 namespace funasr {
 TpassOnlineStream::TpassOnlineStream(TpassStream* tpass_stream, std::vector<int> chunk_size){

--- a/funasr/runtime/onnxruntime/src/tpass-stream.cpp
+++ b/funasr/runtime/onnxruntime/src/tpass-stream.cpp
@@ -1,5 +1,4 @@
 #include "precomp.h"
-#include <unistd.h>
 
 namespace funasr {
 TpassStream::TpassStream(std::map<std::string, std::string>& model_path, int thread_num)


### PR DESCRIPTION

1 funasrruntime.h FUNASRAPI const std::vector<std::vector<float>> CompileHotwordEmbedding(FUNASR_HANDLE handle, std::string &hotwords, ASR_TYPE mode=ASR_OFFLINE); 使用了c++功能，包含在 extern "C" 里面，vc编译会报错。

2 commonfunc.h  #include <codecvt> 在namespace funasr 命名空间里面 vc编译会报错。

3 onnxruntime_c_api.h  ORTCHAR_T  windows定义为wchar_t，linux定义为char，添加宏定义 
#ifdef _WIN32
#define ORTSTRING(str) StrToWstr(str)
#define ORTCHAR(str) StrToWstr(str).c_str()
#else
#define ORTSTRING(str) str
#define ORTCHAR(str) str
#endif
来适配类型不匹配。

4 offline-stream.cpp #include <unistd.h> vc里面没这个头文件，在precomp.h里面加入
#ifdef _WIN32
#include<io.h>
#ifndef R_OK
#define R_OK 4
#endif
#ifndef W_OK
#define W_OK 2
#endif
#ifndef X_OK
#define X_OK 0 
#endif
#ifndef F_OK
#define F_OK 0
#endif
#define access _access
#else
#include <unistd.h>
#endif
解决vc编译问题。

5 audio.cpp   error C4996: 'AVCodecContext::channels': 被声明为已否决, 添加
#ifdef _MSC_VER
#pragma warning(disable:4996)
#endif

6 ct-transformer.cpp  行69 InputData.begin() + i + TOKEN_LEN - nDiff，vc编译后运行断言 vector   dim 越界，需要改成InputData.begin() + i + (TOKEN_LEN - nDiff)，行70同理。

