### PR TITLE
wss_client_fix

### DIFF
--- a/runtime/python/websocket/funasr_wss_client.py
+++ b/runtime/python/websocket/funasr_wss_client.py
@@ -253,6 +253,7 @@ async def message(id):
             wav_name = meg.get("wav_name", "demo")
             text = meg["text"]
             timestamp=""
+            offline_msg_done = meg.get("is_final",False)
             if "timestamp" in meg:
                 timestamp = meg["timestamp"]
 
@@ -262,7 +263,9 @@ async def message(id):
                 else:
                     text_write_line = "{}\t{}\n".format(wav_name, text)
                 ibest_writer.write(text_write_line)
-                
+            
+            if 'mode' not in meg:
+                continue
             if meg["mode"] == "online":
                 text_print += "{}".format(text)
                 text_print = text_print[-args.words_max_print:]
@@ -277,7 +280,7 @@ async def message(id):
                 # text_print = text_print[-args.words_max_print:]
                 # os.system('clear')
                 print("\rpid" + str(id) + ": " + wav_name + ": " + text_print)
-                offline_msg_done = True
+                # offline_msg_done = True
             else:
                 if meg["mode"] == "2pass-online":
                     text_print_2pass_online += "{}".format(text)
@@ -289,7 +292,7 @@ async def message(id):
                 text_print = text_print[-args.words_max_print:]
                 os.system('clear')
                 print("\rpid" + str(id) + ": " + text_print)
-                offline_msg_done=True
+                # offline_msg_done=True
 
     except Exception as e:
             print("Exception:", e)


### PR DESCRIPTION
offline_msg_done 参数在第一次websocket有返回时候就被设置为True，客户端请求offline模式的时候sleep_duration只有0.001，实际客户端音频流发送完毕之后服务端还没有全部处理完，此时客户端根据offline_msg_done判断转写已经结束，于是单方面关闭了websocket连接。
这里根据服务端返回的is_final字段来判断，是否需要关闭客户端连接
服务端返回的is_final字段由客户端发送的is_speaking字段来确定，刚好是处理完最后一条音频数据时会返回为True
#1180 