### PR TITLE
Update funasr_wss_server.py

### DIFF
--- a/runtime/python/websocket/funasr_wss_server.py
+++ b/runtime/python/websocket/funasr_wss_server.py
@@ -179,7 +179,8 @@ async def ws_serve(websocket, path):
 				if "wav_name" in messagejson:
 					websocket.wav_name = messagejson.get("wav_name")
 				if "chunk_size" in messagejson:
-					websocket.status_dict_asr_online["chunk_size"] = messagejson["chunk_size"]
+					chunk_size = messagejson["chunk_size"].split(',')
+					websocket.status_dict_asr_online["chunk_size"] = [int(x) for x in chunk_size]
 				if "encoder_chunk_look_back" in messagejson:
 					websocket.status_dict_asr_online["encoder_chunk_look_back"] = messagejson["encoder_chunk_look_back"]
 				if "decoder_chunk_look_back" in messagejson:


### PR DESCRIPTION
解决报，字符串转成数组并且得是int类型问题

```python
return await cast(
  File "funasr_wss_server.py", line 188, in ws_serve
    int(websocket.status_dict_asr_online["chunk_size"][1]) * 60 / websocket.chunk_interval)
ValueError: invalid literal for int() with base 10: ','
^CTraceback (most recent call last):
  File "funasr_wss_server.py", line 302, in <module>
    asyncio.get_event_loop().run_forever()
```