### PR TITLE
[fix] Fix a bug in seaco_paraformer model "inference" function

### DIFF
--- a/funasr/models/seaco_paraformer/model.py
+++ b/funasr/models/seaco_paraformer/model.py
@@ -350,7 +350,7 @@ class SeacoParaformer(BiCifParaformer, Paraformer):
         pre_acoustic_embeds, pre_token_length = predictor_outs[0], predictor_outs[1]
         pre_token_length = pre_token_length.round().long()
         if torch.max(pre_token_length) < 1:
-            return []
+            return ([],)
 
         decoder_out = self._seaco_decode_with_ASF(encoder_out, 
                                                   encoder_out_lens,


### PR DESCRIPTION
在AutoModel的inference函数中，调用模型inference返回一个空列表[]时，result=res[0]代码会报out of range错误。