### PR TITLE
Fix incorrect assignment of 'end' attribute to 'start'

### DIFF
--- a/runtime/python/http/server.py
+++ b/runtime/python/http/server.py
@@ -117,7 +117,7 @@ async def api_recognition(audio: UploadFile = File(..., description="audio file"
         for sentence in rec_result["sentence_info"]:
             # 每句话的时间戳
             sentences.append(
-                {"text": sentence["text"], "start": sentence["start"], "end": sentence["start"]}
+                {"text": sentence["text"], "start": sentence["start"], "end": sentence["end"]}
             )
         ret = {"text": text, "sentences": sentences, "code": 0}
         logger.info(f"识别结果：{ret}")


### PR DESCRIPTION
Fix incorrect assignment of end timestamp in sentence extraction

The end timestamp for each sentence in the rec_result was erroneously assigned as the start timestamp. 
